### PR TITLE
install lirc,lirc-compat-remotes to use IR remotes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update                                                        && \
 #  - kodi-peripheral-*            enables the use of gamepads, joysticks, game controllers, etc.
 #  - kodi-pvr-*                   PVR add-ons
 #  - kodi-screensaver-*           additional screensavers
+#  - lirc,lirc-compat-remotes     enables the use of IR Remotes
 #  - locales                      additional spoken language support (via x11docker --lang option)
 #  - pulseaudio                   in case the user prefers PulseAudio instead of ALSA
 #  - tzdata                       necessary for timezone selection
@@ -78,6 +79,8 @@ RUN packages="                                               \
     kodi-screensaver-matrixtrails                            \
     kodi-screensaver-pyro                                    \
     kodi-screensaver-stars                                   \
+    lirc                                                     \
+    lirc-compat-remotes                                      \
     locales                                                  \
     pulseaudio                                               \
     libnss3                                                  \

--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ If you want to use them you probably have to mount these devices in the containe
 Please let me know if you have figured out how that works.
 I am happy to add this to the Readme here.
 
+### IR Remotes
+In order to use IR remotes, add this device to your docker file:
+
+```yml
+      - /dev/lirc0:/dev/lirc0
+```
+
+Then once the container is created, you have to manually launch lircd in the container:
+
+```sh
+docker-compose exec  -u root kodi lircd
+```
+
 ## Contributing
 This docker project is based on [erichough/kodi](https://github.com/ehough/docker-kodi).
 


### PR DESCRIPTION
Hi,

Here is a Pull Request to install lirc. It allows the use of IR Remotes to control Kodi.

Still, lirc is not launched by defaut, and require a manual step. Feel free to improve it!

Kind regards,

Adrien